### PR TITLE
fix: update tsconfig to not generate redundant file

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "./node_modules/aegir/src/config/tsconfig.aegir.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "emitDeclarationOnly": true
   },
   "include": [
     "src",


### PR DESCRIPTION
We ony need to generate `.d.ts`, not transpile the js too.